### PR TITLE
Enhancement to command `new`

### DIFF
--- a/src/commands/infra/new.js
+++ b/src/commands/infra/new.js
@@ -19,7 +19,7 @@ class InfraNew extends TwilioClientCommand {
     const repo = 
       validUrl.isUri(args.template) ? 
         args.template :
-        `https://github.com/pulumi/templates/tree/master/${args.template ? args.template : "kubernetes-javascript"}` 
+        `https://github.com/pulumi/templates/tree/master/${args.template ? args.template : "javascript"}` 
     
     const stackName = getStackName(flags, this.twilioClient);
 

--- a/src/commands/infra/new.js
+++ b/src/commands/infra/new.js
@@ -21,9 +21,12 @@ class InfraNew extends TwilioClientCommand {
         args.template :
         `https://github.com/pulumi/templates/tree/master/${args.template ? args.template : "javascript"}` 
     
+    let pulumiArgs = ['new', repo]
     const stackName = getStackName(flags, this.twilioClient);
-
-    child_process.execFileSync('pulumi', ["new", repo, `--stack=${stackName}`], { stdio: 'inherit' });
+    if (stackName) {
+      pulumiArgs.push(`--stack=${stackName}`);
+    }
+    child_process.execFileSync("pulumi", pulumiArgs, { stdio: "inherit" })
 
     return;
   }

--- a/src/commands/infra/new.js
+++ b/src/commands/infra/new.js
@@ -28,6 +28,9 @@ class InfraNew extends TwilioClientCommand {
     }
     child_process.execFileSync("pulumi", pulumiArgs, { stdio: "inherit" })
 
+    // Install twilio-pulumi-provider 
+    child_process.execFileSync("npm", ["install", "twilio", "twilio-pulumi-provider"], { stdio: "inherit" })
+
     return;
   }
 }

--- a/src/commands/infra/stack/new.js
+++ b/src/commands/infra/stack/new.js
@@ -1,14 +1,11 @@
 const { TwilioClientCommand } = require("@twilio/cli-core").baseCommands;
 
 const {
-  cliInfo
-} = require('create-twilio-function/src/command');
-
-const {
   
   convertYargsOptionsToOclifFlags,
   normalizeFlags,
-  getEnvironmentVariables
+  getEnvironmentVariables,
+  options
 
 } = require('../../../utils');
 


### PR DESCRIPTION
The assumption here is that devs will install this CLI to interact with Twilio provider. Also, the default pulumi provider should be something simple (e.g.  `javascript`) since very likely devs will use Twilio backend (at least initially)

* Change default project template to javascript
* Do not pass stack argument if undefined 
* Install Twilio related dependencies